### PR TITLE
README: Fix misspelling of "countrycode" param

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ results.each { |res| p res.address }
 # ...
 
 # We want the city in Canada and results in Japanese
-results = geocoder.geocode('Manchester', country_code: 'CA', language: 'ja')
+results = geocoder.geocode('Manchester', countrycode: 'CA', language: 'ja')
 p results.first.address
 # "Manchester, ノバスコシア州, カナダ"
 p results.first.components


### PR DESCRIPTION
This PR fixes the usage example in the README, to make the country code hinting/filtering work.

Source of information for this fix: https://opencagedata.com/api#forward-opt

Note: The `result` in the example is still correct, with a key "country_code".