### PR TITLE
feat: add alias' for lat and lng

### DIFF
--- a/lib/opencage/geocoder/location.rb
+++ b/lib/opencage/geocoder/location.rb
@@ -21,9 +21,13 @@ module OpenCage
         @result['geometry']['lat'].to_f
       end
 
+      alias latitude lat
+
       def lng
         @result['geometry']['lng'].to_f
       end
+
+      alias longitude lng
 
       def components
         @result['components']


### PR DESCRIPTION
Add alias' for lat -> latitude and
lng -> longitude

closes OpenCageData/ruby-opencage-geocoder#19