### PR TITLE
Set custom default user agent and allow user override

### DIFF
--- a/lib/opencage/geocoder.rb
+++ b/lib/opencage/geocoder.rb
@@ -1,6 +1,7 @@
 require 'opencage/geocoder/location'
 require 'opencage/geocoder/request'
 require 'opencage/error'
+require 'opencage/version'
 require 'open-uri'
 require 'json'
 
@@ -8,6 +9,7 @@ module OpenCage
   class Geocoder
     def initialize(default_options = {})
       @api_key = default_options.fetch(:api_key) { raise_error('401 Missing API key') }
+      @user_agent = default_options.fetch(:user_agent) { "opencage-ruby/#{OpenCage::VERSION} Ruby/#{RUBY_VERSION}" }
     end
 
     def geocode(location, options = {})
@@ -33,9 +35,13 @@ module OpenCage
     private
 
     def fetch(url)
-      JSON.parse(URI(url).open.read)['results']
+      JSON.parse(URI(url).open(headers).read)['results']
     rescue OpenURI::HTTPError => e
       raise_error(e)
+    end
+
+    def headers
+      { 'User-Agent' => @user_agent }
     end
 
     def raise_error(error)

--- a/spec/open_cage/geocoder_spec.rb
+++ b/spec/open_cage/geocoder_spec.rb
@@ -83,4 +83,28 @@ describe OpenCage::Geocoder do
       expect(geo.geocode('NOWHERE-INTERESTING')).to eql([])
     end
   end
+
+  describe 'user agent' do
+    before do
+      stub_request(:get, /api\.opencagedata\.com/)
+        .to_return(body: '{}', status: 200)
+    end
+
+    it 'uses a default user agent' do
+      described_class.new(api_key: ENV.fetch('OPEN_CAGE_API_KEY'))
+                     .geocode('SOMEWHERE')
+
+      expect(WebMock).to have_requested(:get, /api\.opencagedata\.com/)
+        .with(headers: { 'User-Agent' => "opencage-ruby/#{OpenCage::VERSION} Ruby/#{RUBY_VERSION}" })
+    end
+
+    it 'allows a custom user agent to be set' do
+      user_agent = 'my-app/1.0'
+      described_class.new(api_key: ENV.fetch('OPEN_CAGE_API_KEY'), user_agent: user_agent)
+                     .geocode('SOMEWHERE')
+
+      expect(WebMock).to have_requested(:get, /api\.opencagedata\.com/)
+        .with(headers: { 'User-Agent' => user_agent })
+    end
+  end
 end


### PR DESCRIPTION
Add an option `user_agent` to `OpenCage::Geocoder.new` to allow the user to set a custom user agent for all requests. Also set a custom user agent by default with gem and Ruby versions.

I have not updated the version or changelog because I'm not sure how you like to do it.