### PR TITLE
remove rack/rails dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,7 @@ group :development, :test do
   gem 'rubocop-capybara'
   gem 'rubocop-factory_bot'
   gem 'rubocop-performance'
-  gem 'rubocop-rails' # shouldn't be needed, https://github.com/rubocop/rubocop/issues/10893
   gem 'rubocop-rspec'
-  gem 'rubocop-rspec_rails'
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,6 @@ GEM
     prism (1.4.0)
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (3.1.12)
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.10.0)
@@ -104,19 +103,9 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
-    rubocop-rails (2.31.0)
-      activesupport (>= 4.2.0)
-      lint_roller (~> 1.1)
-      rack (>= 1.1)
-      rubocop (>= 1.75.0, < 2.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-rspec (3.5.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
-    rubocop-rspec_rails (2.31.0)
-      lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
-      rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     traces (0.15.2)
@@ -146,9 +135,7 @@ DEPENDENCIES
   rubocop-capybara
   rubocop-factory_bot
   rubocop-performance
-  rubocop-rails
   rubocop-rspec
-  rubocop-rspec_rails
   vcr
   webmock
 


### PR DESCRIPTION
At some point the linter in the test suite `rubocop` started requiring `rack`. No longer needed.