### PR TITLE
Raise InvalidRequest if the query is not a string

### DIFF
--- a/lib/opencage/geocoder.rb
+++ b/lib/opencage/geocoder.rb
@@ -13,6 +13,8 @@ module OpenCage
     end
 
     def geocode(location, options = {})
+      raise_error("400 Not a valid location: `#{location.inspect}`") unless location.is_a?(String)
+
       request = Request.new(@api_key, location, options)
 
       begin

--- a/spec/open_cage/geocoder_spec.rb
+++ b/spec/open_cage/geocoder_spec.rb
@@ -83,7 +83,7 @@ describe OpenCage::Geocoder do
       expect(geo.geocode('NOWHERE-INTERESTING')).to eql([])
     end
 
-    it 'raises and error when undefined query', :vcr do
+    it 'raises an error when undefined query', :vcr do
       expect do
         geo.geocode(nil)
       end.to raise_error(OpenCage::Error::InvalidRequest)
@@ -92,6 +92,12 @@ describe OpenCage::Geocoder do
     it 'raises an error empty query', :vcr do
       expect do
         geo.geocode('')
+      end.to raise_error(OpenCage::Error::InvalidRequest)
+    end
+
+    it 'raises a useful error when the query is not a string' do
+      expect do
+        geo.geocode({ query: 'NOT-A-STRING' }) # it's a hash
       end.to raise_error(OpenCage::Error::InvalidRequest)
     end
   end


### PR DESCRIPTION
- Currently if an invalid location/query is passed to the `OpenCage::Geocoder#geocode` method it will still make a request to the OpenCage API and it might not be immediately clear that the arguments were invalid.
- Throws an `OpenCage::Error::InvalidRequest` if anything other than a string is passed for the query/location.
